### PR TITLE
allow external scroll listener

### DIFF
--- a/Library/src/com/tonicartos/widget/stickygridheaders/StickyGridHeadersGridView.java
+++ b/Library/src/com/tonicartos/widget/stickygridheaders/StickyGridHeadersGridView.java
@@ -245,6 +245,11 @@ public class StickyGridHeadersGridView extends GridView implements OnScrollListe
         super.setOnItemSelectedListener(this);
     }
 
+    @Override
+    public void setOnScrollListener(OnScrollListener listener) {
+        this.mScrollListener = listener;
+    }
+
     private int getHeaderHeight() {
         if (mStickiedHeader != null) {
             return mStickiedHeader.getMeasuredHeight();


### PR DESCRIPTION
the variable was there and used in the internal OnScrollListener, but never settled
