### PR TITLE
StickyGridHeadersGridView passing ReferenceView to onItemClicked

### DIFF
--- a/Library/src/com/tonicartos/widget/stickygridheaders/StickyGridHeadersBaseAdapterWrapper.java
+++ b/Library/src/com/tonicartos/widget/stickygridheaders/StickyGridHeadersBaseAdapterWrapper.java
@@ -471,7 +471,7 @@ public class StickyGridHeadersBaseAdapterWrapper extends BaseAdapter {
      * 
      * @author Anton Spaans, Tonic Artos
      */
-    public class ReferenceView extends FrameLayout {
+    protected class ReferenceView extends FrameLayout {
         private boolean mForceMeasureDisabled;
         private int mNumColumns;
         private int mPosition;

--- a/Library/src/com/tonicartos/widget/stickygridheaders/StickyGridHeadersGridView.java
+++ b/Library/src/com/tonicartos/widget/stickygridheaders/StickyGridHeadersGridView.java
@@ -175,6 +175,10 @@ public class StickyGridHeadersGridView extends GridView implements
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position,
             long id) {
+    	if((view instanceof ReferenceView) && 
+    		((ReferenceView) view).getChildCount() > 0)
+    		view = ((ReferenceView) view).getChildAt(0);
+
         mOnItemClickListener.onItemClick(parent, view,
                 mAdapter.translatePosition(position).mPosition, id);
     }


### PR DESCRIPTION
ReferenceView is protected so it cannot be handled in onItemClick of the listener. Changed the StickyGridHeadersGridView:onItemClick to pass ReferenceView's child.
