### PR TITLE
4 new methods for GridView

### DIFF
--- a/Library/src/com/tonicartos/widget/stickygridheaders/StickyGridHeadersBaseAdapterWrapper.java
+++ b/Library/src/com/tonicartos/widget/stickygridheaders/StickyGridHeadersBaseAdapterWrapper.java
@@ -271,7 +271,7 @@ public class StickyGridHeadersBaseAdapterWrapper extends BaseAdapter {
      * @param header Header set of items are grouped by.
      * @return The count of unfilled spaces in the last row.
      */
-    private int unFilledSpacesInHeaderGroup(int header) {
+    protected int unFilledSpacesInHeaderGroup(int header) {
         int remainder = mDelegate.getCountForHeader(header) % mNumColumns;
         return remainder == 0 ? 0 : mNumColumns - remainder;
     }


### PR DESCRIPTION
4 new methods for StickyGridHeadersGridView.

I'm writing image gallery using your library with "preload image" feature. This means, that when user scroll down gallery, I'm preloading next few pictures to memory, so when user scrolls gallery again images load immediately and everything looks very smooth and cool. On scroll idle I need to know first and last gallery item so I can get next and previous images from my adapter and preload them to memory. That's about "getFirstVisibleAdapterPosition" and "getLastVisibleAdapterPosition".
