### PR TITLE
StickyGridHeadersBaseAdapterWrapper used notifyDataSetChanged (or ..Invalidated) incorrectly

### DIFF
--- a/Library/src/com/tonicartos/widget/stickygridheaders/StickyGridHeadersBaseAdapterWrapper.java
+++ b/Library/src/com/tonicartos/widget/stickygridheaders/StickyGridHeadersBaseAdapterWrapper.java
@@ -24,9 +24,6 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.FrameLayout;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Adapter wrapper to insert extra views and otherwise hack around GridView to
  * add sections and headers.


### PR DESCRIPTION
`notifyDataSetChanged` and `notifyDataSetInvalidated` methods of `StickyGridHeadersBaseAdapterWrapper` were actually useless, since wrapper adapter didn't registered incoming `DataSetObserver`s.
